### PR TITLE
Do not specify classpath elements in manifest file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,10 @@
                     <archive>
                         <manifest>
                             <mainClass>org.jbpm.migration.JbpmMigration</mainClass>
-                            <addClasspath>true</addClasspath>
+                            <!-- Adding classpath will result in warnings in EAP/WildFly in case the exact dependencies
+                                 are not present. Which is the case most of the time as different projects use different
+                                 versions of same artifact (and they are usually compatible so it not an issue). -->
+                            <addClasspath>false</addClasspath>
                         </manifest>
                     </archive>
                 </configuration>


### PR DESCRIPTION
The following warnings are printed by EAP/WildFly in current version:
```
WARN  [org.jboss.as.server.deployment] (MSC service thread 1-1) JBAS015960: Class Path entry xalan-2.7.1.jar in /content/kie-wb.war/WEB-INF/lib/jbpmmigration-0.13.jar  does not point to a valid jar for a Class-Path reference.
```

We depend directly on Xalan module inside EAP, so it is not bundle in the WAR.